### PR TITLE
No need to restart the install script again

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,7 @@ export GOROOT=/usr/local/go
 export GOPATH=\$HOME/go
 export PATH=\$GOPATH/bin:\$GOROOT/bin:\$PATH
 EOF
+source ~/.bashrc
 fi
 
 if [ -f ~/.zshrc ]
@@ -77,8 +78,9 @@ export GOROOT=/usr/local/go
 export GOPATH=\$HOME/go
 export PATH=\$GOPATH/bin:\$GOROOT/bin:\$PATH
 EOF
+source ~/.zshrc
 fi
-printf "${yellow} Golang installed! Open a new terminal and run again this script ${reset}\n"
+# printf "${yellow} Golang installed! Open a new terminal and run again this script ${reset}\n"
 exit
 fi
 


### PR DESCRIPTION
No need to restart the install script again if you give script `sudo chmod +x install.sh` and then run the script as `. ./install.sh`